### PR TITLE
Update to cursive-core 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ repository = "deinstapel/cursive-multiplex"
 repository = "deinstapel/cursive-multiplex"
 
 [dependencies]
-cursive_core = "^0.1"
+cursive_core = "^0.2"
 failure = "0.1.7"
 failure_derive = "0.1.7"
 indextree = "4.0.0"
 log = "0.4.8"
 
 [dev-dependencies]
-crossbeam = "^0.7"
-cursive = "^0.15"
+crossbeam = "^0.8"
+cursive = "^0.16"
 serde_json = "1.0.48"
 insta = "^0.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod path;
 
 use cursive_core::direction::{Absolute, Direction};
 use cursive_core::event::{AnyCb, Event, EventResult, Key, MouseButton, MouseEvent};
-use cursive_core::view::{Selector, View};
+use cursive_core::view::{Selector, View, ViewNotFound};
 use cursive_core::{Printer, Vec2};
 pub use error::*;
 pub use id::Id;
@@ -116,7 +116,7 @@ impl View for Mux {
         true
     }
 
-    fn focus_view(&mut self, _: &Selector) -> Result<(), ()> {
+    fn focus_view(&mut self, _: &Selector) -> Result<(), ViewNotFound> {
         Ok(())
     }
 
@@ -135,11 +135,14 @@ impl View for Mux {
             offset,
             position,
             event,
-        } = evt {
+        } = evt
+        {
             if let MouseEvent::Press(MouseButton::Left) = event {
                 if let Some(off_pos) = position.checked_sub(offset) {
                     if let Some(pane) = self.clicked_pane(off_pos) {
-                        if self.tree.get_mut(pane).unwrap().get_mut().take_focus() && self.focus != pane {
+                        if self.tree.get_mut(pane).unwrap().get_mut().take_focus()
+                            && self.focus != pane
+                        {
                             self.focus = pane;
                             self.invalidated = true;
                         }

--- a/tests/end2end.rs
+++ b/tests/end2end.rs
@@ -14,7 +14,7 @@ where
     let backend = Backend::init(Some(Vec2::new(80, 24)));
     let frames = backend.stream();
     let input = backend.input();
-    let mut siv = cursive::Cursive::new(|| backend);
+    let mut siv = cursive::Cursive::new().into_runner(backend);
     cb(&mut siv);
     input
         .send(Some(Event::Refresh))
@@ -24,7 +24,7 @@ where
 }
 
 struct TestCursive {
-    siv: cursive::Cursive,
+    siv: cursive::CursiveRunner<cursive::Cursive>,
     frames: Receiver<ObservedScreen>,
     input: Sender<Option<Event>>,
 }
@@ -37,7 +37,7 @@ impl TestCursive {
         let backend = Backend::init(Some(Vec2::new(80, 24)));
         let frames = backend.stream();
         let input = backend.input();
-        let mut siv = cursive::Cursive::new(|| backend);
+        let mut siv = cursive::Cursive::new().into_runner(backend);
         cb(&mut siv);
         input
             .send(Some(Event::Refresh))

--- a/tests/geometric.rs
+++ b/tests/geometric.rs
@@ -1,14 +1,13 @@
 use cursive_core::event::{Event, Key};
 use cursive_core::traits::View;
 use cursive_core::views::{NamedView, TextArea};
-use cursive_core::Cursive;
 use cursive_multiplex::Mux;
 
 #[test]
 fn test_line_vertical() {
     // Vertical test
 
-    let mut siv = Cursive::dummy();
+    let mut siv = cursive::dummy();
 
     println!("Vertical Test");
     let mut test_mux = Mux::new();
@@ -43,7 +42,7 @@ fn test_triangle() {
     let node1 = mux
         .add_right_of(TextArea::new(), mux.root().build().unwrap())
         .expect("first failed");
-    let mut siv = Cursive::dummy();
+    let mut siv = cursive::dummy();
 
     let node2 = mux.add_right_of(TextArea::new(), node1).unwrap();
     let node3 = mux.add_below(TextArea::new(), node2).unwrap();
@@ -76,7 +75,7 @@ fn test_diagonal() {
     let node1 = mux
         .add_right_of(TextArea::new(), mux.root().build().unwrap())
         .expect("first failed");
-    let mut siv = Cursive::dummy();
+    let mut siv = cursive::dummy();
 
     let node2 = mux.add_right_of(TextArea::new(), node1).unwrap();
     let _ = mux.add_below(TextArea::new(), node2).unwrap();
@@ -112,7 +111,7 @@ fn test_diagonal() {
 fn test_quadratic() {
     // Quadratic test
 
-    let mut siv = Cursive::dummy();
+    let mut siv = cursive::dummy();
     let mut mux = Mux::new();
     let top_left_corner = mux
         .add_right_of(TextArea::new(), mux.root().build().unwrap())


### PR DESCRIPTION
cursive-core 0.2 changes a bit the way the backend is given to the `Cursive` instance.
In addition it uses crossbeam 0.8.