### PR TITLE
Update cursive-core to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ repository = "https://github.com/deinstapel/cursive-multiplex"
 version = "0.5.2-alpha.0"
 
 [dependencies]
-cursive_core = "0.2"
+cursive_core = "0.3"
 thiserror = "1.0"
 indextree = "4.3"
 log = "0.4"
 
 [dev-dependencies]
 crossbeam = "0.8"
-cursive = "0.16"
+cursive = "0.17"
 serde_json = "1.0"
 insta = "1.7"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,7 @@
-use cursive::{Cursive, views::{LinearLayout, Menubar, NamedView, ResizedView, ScrollView, TextArea}};
+use cursive::{
+    views::{LinearLayout, Menubar, NamedView, ResizedView, ScrollView, TextArea},
+    Cursive,
+};
 use cursive_core::{direction::Orientation, views::TextView};
 use cursive_multiplex::Mux;
 
@@ -30,20 +33,19 @@ Integer sit amet eleifend ex. Vivamus aliquam eros et massa pellentesque gravida
     menubar.add_leaf("Feel free to try out the examples simply with `cargo run --example=basic` or `cargo run --example=tily`", |_|{});
 
     let node2 = mux
-        .add_right_of(
-            ResizedView::with_full_screen(TextArea::new()),
-            node1,
-        )
+        .add_right_of(ResizedView::with_full_screen(TextArea::new()), node1)
         .unwrap();
     if let Some(textview) = mux.active_view_mut() {
-        let valid_view = textview.downcast_mut::<ResizedView<TextArea>>().unwrap().get_inner_mut();
-        valid_view.set_content("This text is added by later modification! Check out the `basic` example to see how.");
+        let valid_view = textview
+            .downcast_mut::<ResizedView<TextArea>>()
+            .unwrap()
+            .get_inner_mut();
+        valid_view.set_content(
+            "This text is added by later modification! Check out the `basic` example to see how.",
+        );
     }
     let _ = mux
-        .add_below(
-            ResizedView::with_full_screen(TextArea::new()),
-            node2,
-        )
+        .add_below(ResizedView::with_full_screen(TextArea::new()), node2)
         .unwrap();
 
     mux.set_container_split_ratio(node2, 0.7).unwrap();

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -30,7 +30,8 @@ fn main() {
         .unwrap();
 
     let idlayer = cursive_core::views::NamedView::new("Mux", mux);
-    let mut linear = cursive_core::views::LinearLayout::new(cursive_core::direction::Orientation::Vertical);
+    let mut linear =
+        cursive_core::views::LinearLayout::new(cursive_core::direction::Orientation::Vertical);
 
     linear.add_child(idlayer);
     linear.add_child(menubar);

--- a/examples/skewed.rs
+++ b/examples/skewed.rs
@@ -30,7 +30,8 @@ fn main() {
         .unwrap();
 
     let idlayer = cursive_core::views::NamedView::new("Mux", mux);
-    let mut linear = cursive_core::views::LinearLayout::new(cursive_core::direction::Orientation::Vertical);
+    let mut linear =
+        cursive_core::views::LinearLayout::new(cursive_core::direction::Orientation::Vertical);
 
     linear.add_child(idlayer);
     linear.add_child(menubar);

--- a/examples/tily.rs
+++ b/examples/tily.rs
@@ -75,6 +75,9 @@ fn main() {
 
 fn add_plane(siv: &mut Cursive, node: Id) {
     let mut foo: cursive_core::views::ViewRef<Mux> = siv.find_name("Steven").unwrap();
-    foo.add_below(cursive_core::views::TextView::new("Dynamic!".to_string()), node)
-        .unwrap();
+    foo.add_below(
+        cursive_core::views::TextView::new("Dynamic!".to_string()),
+        node,
+    )
+    .unwrap();
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -45,9 +45,9 @@ impl Mux {
                 // Traverse the path down again
                 if let Some(focus) = self.traverse_search_path(path, turn_point, direction, origin)
                 {
-                    if self.tree.get_mut(focus).unwrap().get_mut().take_focus() {
+                    if let Ok(result) = self.tree.get_mut(focus).unwrap().get_mut().take_focus() {
                         self.focus = focus;
-                        EventResult::Consumed(None)
+                        EventResult::Consumed(None).and(result)
                     } else {
                         // rejected
                         self.move_focus_relative(direction, focus, origin)

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -61,12 +61,8 @@ impl Mux {
     }
 
     fn traverse_single_node(&self, action: SearchPath, turn_point: Id, cur_node: Id) -> Option<Id> {
-        let left = || -> Option<Id> {
-            cur_node.children(&self.tree).next()
-        };
-        let right = || -> Option<Id> {
-            cur_node.children(&self.tree).last()
-        };
+        let left = || -> Option<Id> { cur_node.children(&self.tree).next() };
+        let right = || -> Option<Id> { cur_node.children(&self.tree).last() };
         let up = left;
         let down = right;
         match self.tree.get(turn_point).unwrap().get().orientation {

--- a/src/id.rs
+++ b/src/id.rs
@@ -140,15 +140,27 @@ impl Mux {
     /// mux.set_container_split_ratio(new_node, 0.3).unwrap();
     /// # }
     /// ```
-    pub fn set_container_split_ratio<T: Into<f32>>(&mut self, id: Id, input: T) -> Result<(), AddViewError> {
+    pub fn set_container_split_ratio<T: Into<f32>>(
+        &mut self,
+        id: Id,
+        input: T,
+    ) -> Result<(), AddViewError> {
         let ratio = input.into().clamp(0.0, 1.0);
-        if let Some(parent_id) = self.tree.get(id).ok_or(AddViewError::GenericError{})?.parent() {
-            let parent = self.tree.get_mut(parent_id).ok_or(AddViewError::GenericError{})?.get_mut();
+        if let Some(parent_id) = self
+            .tree
+            .get(id)
+            .ok_or(AddViewError::GenericError {})?
+            .parent()
+        {
+            let parent = self
+                .tree
+                .get_mut(parent_id)
+                .ok_or(AddViewError::GenericError {})?
+                .get_mut();
             parent.split_ratio = ratio;
-            return Ok(())
+            return Ok(());
         }
-        Err(AddViewError::GenericError{})
-
+        Err(AddViewError::GenericError {})
     }
 
     fn add_node_id<T>(
@@ -193,7 +205,9 @@ impl Mux {
 
             node_id.detach(&mut self.tree);
 
-            let new_intermediate = self.tree.new_node(Node::new_empty(orientation, self.default_split_ratio));
+            let new_intermediate = self
+                .tree
+                .new_node(Node::new_empty(orientation, self.default_split_ratio));
             match position {
                 SearchPath::Right | SearchPath::Down => {
                     parent.append(new_intermediate, &mut self.tree);
@@ -255,11 +269,11 @@ impl Mux {
                         Ok(())
                     }
                 } else if parent2.children(&self.tree).next().unwrap() == snd {
-                        fst.detach(&mut self.tree);
-                        snd.detach(&mut self.tree);
-                        parent1.checked_append(snd, &mut self.tree)?;
-                        parent2.checked_prepend(fst, &mut self.tree)?;
-                        Ok(())
+                    fst.detach(&mut self.tree);
+                    snd.detach(&mut self.tree);
+                    parent1.checked_append(snd, &mut self.tree)?;
+                    parent2.checked_prepend(fst, &mut self.tree)?;
+                    Ok(())
                 } else {
                     fst.detach(&mut self.tree);
                     snd.detach(&mut self.tree);

--- a/src/id.rs
+++ b/src/id.rs
@@ -229,7 +229,16 @@ impl Mux {
             debug!("Changed order");
         }
 
-        if self.tree.get_mut(new_node).unwrap().get_mut().take_focus() {
+        if self
+            .tree
+            .get_mut(new_node)
+            .unwrap()
+            .get_mut()
+            .take_focus()
+            .is_ok()
+        {
+            // Here we discard the potential callback from the focused view.
+            // Ideally we would bubble it up so it can be processed.
             self.focus = new_node;
             debug!("Changed Focus: {}", new_node);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,7 @@ impl View for Mux {
         {
             if let Some(off_pos) = position.checked_sub(offset) {
                 if let Some(pane) = self.clicked_pane(off_pos) {
-                    if self.tree.get_mut(pane).unwrap().get_mut().take_focus()
-                        && self.focus != pane
+                    if self.tree.get_mut(pane).unwrap().get_mut().take_focus() && self.focus != pane
                     {
                         self.focus = pane;
                         self.invalidated = true;
@@ -204,19 +203,17 @@ impl Mux {
     }
 
     pub fn active_view(&self) -> Option<&dyn View> {
-        self.tree.get(self.focus)
+        self.tree
+            .get(self.focus)
             .map(|node| node.get())
-            .and_then(|node| {
-                node.view.as_deref()
-            })
+            .and_then(|node| node.view.as_deref())
     }
 
     pub fn active_view_mut(&mut self) -> Option<&mut dyn View> {
-        self.tree.get_mut(self.focus)
+        self.tree
+            .get_mut(self.focus)
             .map(|node| node.get_mut())
-            .and_then(|node| {
-              node.view.as_deref_mut()
-            })
+            .and_then(|node| node.view.as_deref_mut())
     }
 
     /// Chainable setter for the default split ratio.
@@ -233,7 +230,6 @@ impl Mux {
         self.default_split_ratio = split.into().clamp(0.0, 1.0);
         self.tree.get_mut(self.root).unwrap().get_mut().split_ratio = self.default_split_ratio;
     }
-
 
     /// Chainable setter for action
     pub fn with_move_focus_up(mut self, evt: Event) -> Self {
@@ -373,7 +369,10 @@ impl Mux {
                 match orit {
                     Orientation::Horizontal => {
                         const1 = Vec2::new(
-                            Mux::add_offset((constraint.x as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset),
+                            Mux::add_offset(
+                                (constraint.x as f32 * root_data.split_ratio) as usize,
+                                root_data.split_ratio_offset,
+                            ),
                             constraint.y,
                         );
                         const2 = Vec2::new(
@@ -397,11 +396,16 @@ impl Mux {
                     Orientation::Vertical => {
                         const1 = Vec2::new(
                             constraint.x,
-                            Mux::add_offset((constraint.y as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset),
+                            Mux::add_offset(
+                                (constraint.y as f32 * root_data.split_ratio) as usize,
+                                root_data.split_ratio_offset,
+                            ),
                         );
                         const2 = Vec2::new(constraint.x, {
-                            let size =
-                                Mux::add_offset((constraint.y as f32 * root_data.split_ratio) as usize, -root_data.split_ratio_offset);
+                            let size = Mux::add_offset(
+                                (constraint.y as f32 * root_data.split_ratio) as usize,
+                                -root_data.split_ratio_offset,
+                            );
                             if constraint.y % 2 == 0 {
                                 match size.checked_sub(1) {
                                     Some(res) => res,
@@ -477,34 +481,50 @@ impl Mux {
                 match root_data.orientation {
                     Orientation::Horizontal => {
                         printer1 = printer.cropped(Vec2::new(
-                            Mux::add_offset((printer.size.x as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset),
+                            Mux::add_offset(
+                                (printer.size.x as f32 * root_data.split_ratio) as usize,
+                                root_data.split_ratio_offset,
+                            ),
                             printer.size.y,
                         ));
                         printer2 = printer
                             .offset(Vec2::new(
-                                Mux::add_offset((printer.size.x as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset)
-                                    + 1,
+                                Mux::add_offset(
+                                    (printer.size.x as f32 * root_data.split_ratio) as usize,
+                                    root_data.split_ratio_offset,
+                                ) + 1,
                                 0,
                             ))
                             .cropped(Vec2::new(
-                                Mux::add_offset((printer.size.x as f32 * root_data.split_ratio) as usize, -root_data.split_ratio_offset),
+                                Mux::add_offset(
+                                    (printer.size.x as f32 * root_data.split_ratio) as usize,
+                                    -root_data.split_ratio_offset,
+                                ),
                                 printer.size.y,
                             ));
                     }
                     Orientation::Vertical => {
                         printer1 = printer.cropped(Vec2::new(
                             printer.size.x,
-                            Mux::add_offset((printer.size.y as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset),
+                            Mux::add_offset(
+                                (printer.size.y as f32 * root_data.split_ratio) as usize,
+                                root_data.split_ratio_offset,
+                            ),
                         ));
                         printer2 = printer
                             .offset(Vec2::new(
                                 0,
-                                Mux::add_offset((printer.size.y as f32 * root_data.split_ratio) as usize, root_data.split_ratio_offset)
-                                    + 1,
+                                Mux::add_offset(
+                                    (printer.size.y as f32 * root_data.split_ratio) as usize,
+                                    root_data.split_ratio_offset,
+                                ) + 1,
                             ))
                             .cropped(Vec2::new(
                                 printer.size.x,
-                                Mux::add_offset((printer.size.y as f32 * root_data.split_ratio) as usize, -root_data.split_ratio_offset),
+                                Mux::add_offset(
+                                    (printer.size.y as f32 * root_data.split_ratio) as usize,
+                                    -root_data.split_ratio_offset,
+                                ),
                             ));
                     }
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,7 @@
 use crate::error::RenderError;
 use crate::{AnyCb, Direction, Event, EventResult, Orientation, Printer, Selector, Vec2, View};
 use cursive_core::direction::Absolute;
+use cursive_core::view::CannotFocus;
 
 pub(crate) struct Node {
     pub(crate) view: Option<Box<dyn View>>,
@@ -159,11 +160,11 @@ impl Node {
         }
     }
 
-    pub(crate) fn take_focus(&mut self) -> bool {
+    pub(crate) fn take_focus(&mut self) -> Result<EventResult, CannotFocus> {
         if let Some(view) = self.view.as_mut() {
             view.take_focus(Direction::none())
         } else {
-            false
+            Err(CannotFocus)
         }
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
+use crate::error::RenderError;
 use crate::{AnyCb, Direction, Event, EventResult, Orientation, Printer, Selector, Vec2, View};
 use cursive_core::direction::Absolute;
-use crate::error::RenderError;
 
 pub(crate) struct Node {
     pub(crate) view: Option<Box<dyn View>>,
@@ -24,8 +24,7 @@ impl Node {
             split_ratio: 0.5,
             total_position: None,
             size: None,
-            total_size: None
-
+            total_size: None,
         }
     }
 
@@ -46,56 +45,60 @@ impl Node {
             match direction {
                 Absolute::Left | Absolute::Up => match direction.into() {
                     Orientation::Horizontal => {
-                        if (total_size.x as f32 * self.split_ratio) as i16 - self.split_ratio_offset.abs()
+                        if (total_size.x as f32 * self.split_ratio) as i16
+                            - self.split_ratio_offset.abs()
                             > 1
                             || self.split_ratio_offset > 0
                         {
                             self.split_ratio_offset -= 1;
                             Ok(())
                         } else {
-                            Err(RenderError::Arithmetic{})
+                            Err(RenderError::Arithmetic {})
                         }
                     }
                     Orientation::Vertical => {
-                        if (total_size.y as f32 * self.split_ratio) as i16 - self.split_ratio_offset.abs()
+                        if (total_size.y as f32 * self.split_ratio) as i16
+                            - self.split_ratio_offset.abs()
                             > 1
                             || self.split_ratio_offset > 0
                         {
                             self.split_ratio_offset -= 1;
                             Ok(())
                         } else {
-                            Err(RenderError::Arithmetic{})
+                            Err(RenderError::Arithmetic {})
                         }
                     }
                 },
                 Absolute::Right | Absolute::Down => match direction.into() {
                     Orientation::Horizontal => {
-                        if (total_size.x as f32 * (1.0 - self.split_ratio)) as i16 - self.split_ratio_offset.abs()
+                        if (total_size.x as f32 * (1.0 - self.split_ratio)) as i16
+                            - self.split_ratio_offset.abs()
                             > 1
                             || self.split_ratio_offset < 0
                         {
                             self.split_ratio_offset += 1;
                             Ok(())
                         } else {
-                            Err(RenderError::Arithmetic{})
+                            Err(RenderError::Arithmetic {})
                         }
                     }
                     Orientation::Vertical => {
-                        if (total_size.y as f32 * (1.0 - self.split_ratio)) as i16 - self.split_ratio_offset.abs()
+                        if (total_size.y as f32 * (1.0 - self.split_ratio)) as i16
+                            - self.split_ratio_offset.abs()
                             > 1
                             || self.split_ratio_offset < 0
                         {
                             self.split_ratio_offset += 1;
                             Ok(())
                         } else {
-                            Err(RenderError::Arithmetic{})
+                            Err(RenderError::Arithmetic {})
                         }
                     }
                 },
-                _ => Err(RenderError::Arithmetic{}),
+                _ => Err(RenderError::Arithmetic {}),
             }
         } else {
-            Err(RenderError::Arithmetic{})
+            Err(RenderError::Arithmetic {})
         }
     }
 

--- a/tests/end2end.rs
+++ b/tests/end2end.rs
@@ -670,7 +670,8 @@ fn end2end_custom_split_ratio_overshoot_correction() {
         let first = mux
             .add_right_of(TextArea::new(), mux.root().build().unwrap())
             .expect("First Insert failed");
-        mux.set_container_split_ratio(first, 0.5).expect("Could not modify id");
+        mux.set_container_split_ratio(first, 0.5)
+            .expect("Could not modify id");
         let _ = mux.add_left_of(TextView::new("A very very long text to demonstrate the split that happens later on in this example."), first).expect("Could not add second view.");
         siv.add_fullscreen_layer(mux);
     });


### PR DESCRIPTION
The main change from cursive-core 0.3.0 is that the `take_focus()` method now returns a `Result<EventResult, CannotFocus>`.

This means that as much as possible, the `EventResult` should be bubbled up, or processed when possible.


Note: my editor automatically runs `rustfmt`, and apparently that wasn't the style used before this PR. If you have a favorite style (I see a `.editorconfig`), it may be possible to translate it as a rustfmt.toml, such that applying rustfmt results in the desired style.
If you add such a file, I could rebase this PR to reduce the diff.